### PR TITLE
PDM support for I2S

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -29,7 +29,8 @@ BUILD ?= build-$(BOARD)
 endif
 
 # Device serial settings.
-PORT ?= /dev/ttyUSB0
+#PORT ?= /dev/ttyUSB0
+PORT ?= /dev/ttyACM0
 BAUD ?= 460800
 
 PYTHON ?= python3

--- a/ports/esp32/machine_i2s.c
+++ b/ports/esp32/machine_i2s.c
@@ -59,6 +59,8 @@
 // The size of 240 bytes is an engineering optimum that balances transfer performance with an acceptable use of heap space
 #define SIZEOF_TRANSFORM_BUFFER_IN_BYTES (240)
 
+#define I2S_NUM_MAX 2
+
 typedef enum {
     I2S_TX_TRANSFER,
     I2S_RX_TRANSFER,
@@ -507,7 +509,7 @@ typedef struct _machine_hw_i2s_obj_t {
 //   note:  I2S implementation makes use of the following mapping between I2S peripheral and I2S object
 //      I2S peripheral 1:  machine_hw_i2s_obj[0]
 //      I2S peripheral 2:  machine_hw_i2s_obj[1]
-STATIC machine_hw_i2s_obj_t machine_hw_i2s_obj[I2S_NUM_AUTO] = {
+STATIC machine_hw_i2s_obj_t machine_hw_i2s_obj[I2S_NUM_MAX] = {
         [0].used = false,
         [1].used = false };
 

--- a/ports/esp32/machine_i2s.c
+++ b/ports/esp32/machine_i2s.c
@@ -36,6 +36,14 @@
 #include "freertos/queue.h"
 #include "esp_task.h"
 
+#include <string.h>
+#include "py/obj.h"
+#include "py/runtime.h"
+#include "modmachine.h"
+#include "mphalport.h"
+#include "driver/i2s.h"
+
+
 // Notes on this port's specific implementation of I2S:
 // - a FreeRTOS task is created to implement the asynchronous background operations
 // - a FreeRTOS queue is used to transfer the supplied buffer to the background task
@@ -465,3 +473,441 @@ STATIC void mp_machine_i2s_irq_update(machine_i2s_obj_t *self) {
 }
 
 MP_REGISTER_ROOT_POINTER(struct _machine_i2s_obj_t *machine_i2s_obj[I2S_NUM_AUTO]);
+
+
+
+
+// Notes on naming conventions:
+// 1. "id" versus "port"
+//    The MicroPython API identifies instances of a peripheral using "id", while the ESP-IDF uses "port".
+//    - for example, the first I2S peripheral on the ESP32 would be indicated by id=0 in MicroPython
+//      and port=0 in ESP-IDF
+// 2. any C type, macro, or function prefaced by "i2s" is associated with an ESP-IDF I2S interface definition
+// 3. any C type, macro, or function prefaced by "machine_hw_i2s" is associated with the MicroPython implementation of I2S
+
+typedef struct _machine_hw_i2s_obj_t {
+    mp_obj_base_t          base;
+    i2s_port_t             id;
+    i2s_comm_format_t      standard;
+    uint8_t                mode;
+    i2s_bits_per_sample_t  dataformat;
+    i2s_channel_fmt_t      channelformat;
+    int32_t                samplerate;
+    int16_t                dmacount;
+    int16_t                dmalen;
+    int32_t                apllrate;
+    int8_t                 bck;
+    int8_t                 ws;
+    int8_t                 sdout;
+    int8_t                 sdin;
+    bool                   used;
+} machine_hw_i2s_obj_t;
+
+// Static object mapping to I2S peripherals
+//   note:  I2S implementation makes use of the following mapping between I2S peripheral and I2S object
+//      I2S peripheral 1:  machine_hw_i2s_obj[0]
+//      I2S peripheral 2:  machine_hw_i2s_obj[1]
+STATIC machine_hw_i2s_obj_t machine_hw_i2s_obj[I2S_NUM_AUTO] = {
+        [0].used = false,
+        [1].used = false };
+
+STATIC void machine_hw_i2s_init_helper(machine_hw_i2s_obj_t *self, size_t n_pos_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+
+    enum {
+        ARG_bck,
+        ARG_ws,
+        ARG_sdout,
+        ARG_sdin,
+        ARG_standard,
+        ARG_mode,
+        ARG_dataformat,
+        ARG_channelformat,
+        ARG_samplerate,
+        ARG_dmacount,
+        ARG_dmalen,
+        ARG_apllrate,
+    };
+
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_bck,              MP_ARG_KW_ONLY                   | MP_ARG_OBJ,   {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_ws,               MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_OBJ,   {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_sdout,            MP_ARG_KW_ONLY                   | MP_ARG_OBJ,   {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_sdin,             MP_ARG_KW_ONLY                   | MP_ARG_OBJ,   {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_standard,         MP_ARG_KW_ONLY                   | MP_ARG_INT,   {.u_int = I2S_COMM_FORMAT_I2S} },
+        { MP_QSTR_mode,             MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_INT,   {.u_int = -1} },
+        { MP_QSTR_dataformat,       MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_INT,   {.u_int = -1} },
+        { MP_QSTR_channelformat,    MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_INT,   {.u_int = -1} },
+        { MP_QSTR_samplerate,       MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_INT,   {.u_int = -1} },
+        { MP_QSTR_dmacount,         MP_ARG_KW_ONLY                   | MP_ARG_INT,   {.u_int = 16} },
+        { MP_QSTR_dmalen,           MP_ARG_KW_ONLY                   | MP_ARG_INT,   {.u_int = 64} },
+        { MP_QSTR_apllrate,         MP_ARG_KW_ONLY                   | MP_ARG_INT,   {.u_int = 0} },
+    };
+
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_pos_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    
+    //
+    // ---- Check validity of arguments ----
+    //
+
+    // are I2S pin assignments valid?
+    int8_t bck = args[ARG_bck].u_obj == MP_OBJ_NULL ? -1 : machine_pin_get_id(args[ARG_bck].u_obj);
+    int8_t ws = args[ARG_ws].u_obj == MP_OBJ_NULL ? -1 : machine_pin_get_id(args[ARG_ws].u_obj);
+    int8_t sdin = args[ARG_sdin].u_obj == MP_OBJ_NULL ? -1 : machine_pin_get_id(args[ARG_sdin].u_obj);
+    int8_t sdout = args[ARG_sdout].u_obj == MP_OBJ_NULL ? -1 : machine_pin_get_id(args[ARG_sdout].u_obj);
+
+    if ((sdin == -1) && (args[ARG_mode].u_int == (I2S_MODE_MASTER | I2S_MODE_RX))) {
+        mp_raise_ValueError(MP_ERROR_TEXT("sdin must be specified for RX mode"));
+    }
+
+    if ((sdin == -1) && (args[ARG_mode].u_int == (I2S_MODE_MASTER | I2S_MODE_RX | I2S_MODE_PDM))) {
+        mp_raise_ValueError(MP_ERROR_TEXT("sdin must be specified for PDM mode"));
+    }
+
+    if ((sdout == -1) && (args[ARG_mode].u_int == (I2S_MODE_MASTER | I2S_MODE_TX))) {
+        mp_raise_ValueError(MP_ERROR_TEXT("sdout must be specified for TX mode"));
+    }
+
+    if ((sdin != -1) && (sdout != -1)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("only one of sdin or sdout can be specified"));
+    }
+
+    if ((bck == -1) && (args[ARG_mode].u_int == (I2S_MODE_MASTER | I2S_MODE_RX) || args[ARG_mode].u_int == (I2S_MODE_MASTER | I2S_MODE_TX))) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bck must be specified for RX/TX mode"));
+    }
+
+    // if pdm only I2S_NUM_0 supported
+    if ((self->id != 0) && (args[ARG_mode].u_int == (I2S_MODE_MASTER | I2S_MODE_RX | I2S_MODE_PDM))) {
+        mp_raise_ValueError(MP_ERROR_TEXT("I2S.NS0 only supports PDM mode"));
+    }
+
+    // is Standard valid?
+    i2s_comm_format_t i2s_commformat = args[ARG_standard].u_int;
+    if ((i2s_commformat != I2S_COMM_FORMAT_I2S) &&
+        (i2s_commformat != (I2S_COMM_FORMAT_I2S | I2S_COMM_FORMAT_I2S_LSB))) {
+        mp_raise_ValueError(MP_ERROR_TEXT("Standard is not valid"));
+    }
+
+    // is Mode valid?
+    i2s_mode_t i2s_mode = args[ARG_mode].u_int;
+    if ((i2s_mode != (I2S_MODE_MASTER | I2S_MODE_RX)) &&
+        (i2s_mode != (I2S_MODE_MASTER | I2S_MODE_TX)) &&
+        (i2s_mode != (I2S_MODE_MASTER | I2S_MODE_RX | I2S_MODE_PDM))) {
+        mp_raise_ValueError(MP_ERROR_TEXT("Only Master Rx, Master Tx, Master PDM Modes are supported"));
+    }
+
+    // is Data Format valid?
+    i2s_bits_per_sample_t i2s_bits_per_sample = args[ARG_dataformat].u_int;
+    if ((i2s_bits_per_sample != I2S_BITS_PER_SAMPLE_16BIT) &&
+        (i2s_bits_per_sample != I2S_BITS_PER_SAMPLE_24BIT) &&
+        (i2s_bits_per_sample != I2S_BITS_PER_SAMPLE_32BIT)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("Data Format is not valid"));
+    }
+
+    // is Channel Format valid?
+    i2s_channel_fmt_t i2s_channelformat = args[ARG_channelformat].u_int;
+    if ((i2s_channelformat != I2S_CHANNEL_FMT_RIGHT_LEFT) &&
+        (i2s_channelformat != I2S_CHANNEL_FMT_ALL_RIGHT) &&
+        (i2s_channelformat != I2S_CHANNEL_FMT_ALL_LEFT) &&
+        (i2s_channelformat != I2S_CHANNEL_FMT_ONLY_RIGHT) &&
+        (i2s_channelformat != I2S_CHANNEL_FMT_ONLY_LEFT)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("Channel Format is not valid"));
+    }
+
+    // is Sample Rate valid?
+    // No validation done:  ESP-IDF API does not indicate a valid range for sample rate
+
+    // is DMA Buffer Count valid?
+    // ESP-IDF API code checks for buffer count in this range:  [2, 128]
+    int16_t i2s_dmacount = args[ARG_dmacount].u_int;
+    if ((i2s_dmacount < 2) || (i2s_dmacount > 128)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("DMA Buffer Count is not valid.  Allowed range is [2, 128]"));
+    }
+
+    // is DMA Buffer Length valid?
+    // ESP-IDF API code checks for buffer length in this range:  [8, 1024]
+    int16_t i2s_dmalen = args[ARG_dmalen].u_int;
+    if ((i2s_dmalen < 8) || (i2s_dmalen > 1024)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("DMA Buffer Length is not valid.  Allowed range is [8, 1024]"));
+    }
+
+    // is APLL Rate valid?
+    // No validation done:  ESP-IDF API does not indicate a valid range for APLL rate
+    
+
+    self->bck = bck;
+    self->ws = ws;
+    self->sdout = sdout;
+    self->sdin = sdin;
+    self->standard = args[ARG_standard].u_int;
+    self->mode = args[ARG_mode].u_int;
+    self->dataformat = args[ARG_dataformat].u_int;
+    self->channelformat = args[ARG_channelformat].u_int;
+    self->samplerate = args[ARG_samplerate].u_int;
+    self->dmacount = args[ARG_dmacount].u_int;
+    self->dmalen = args[ARG_dmalen].u_int;
+    self->apllrate = args[ARG_apllrate].u_int;
+
+    i2s_config_t i2s_config;
+    i2s_config.communication_format = self->standard;
+    i2s_config.mode = self->mode;
+    i2s_config.bits_per_sample = self->dataformat;
+    i2s_config.channel_format = self->channelformat;
+    i2s_config.sample_rate = self->samplerate;
+    i2s_config.intr_alloc_flags = ESP_INTR_FLAG_LEVEL1;
+    i2s_config.dma_buf_count = self->dmacount;
+    i2s_config.dma_buf_len = self->dmalen;
+    if (self->apllrate != 0) {
+        i2s_config.use_apll = true;
+    } else {
+        i2s_config.use_apll = false;
+        i2s_config.tx_desc_auto_clear = true;
+    }
+    i2s_config.fixed_mclk = self->apllrate;
+
+    // uninstall I2S driver when changes are being made to an active I2S peripheral
+    if (self->used) {
+        i2s_driver_uninstall(self->id);
+    }
+
+    esp_err_t ret = i2s_driver_install(self->id, &i2s_config, 0, NULL);
+    switch (ret) {
+        case ESP_OK:
+            break;
+        case ESP_ERR_INVALID_ARG:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("I2S driver install: Parameter error"));
+            break;
+        case ESP_ERR_NO_MEM:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("I2S driver install: Out of memory"));
+            break;
+        default:
+            // this error not documented in ESP-IDF
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("I2S driver install: Undocumented error")); 
+            break;
+    }
+
+    i2s_pin_config_t pin_config;
+    pin_config.bck_io_num = self->bck;
+    pin_config.ws_io_num = self->ws;
+    pin_config.data_out_num = self->sdout;
+    pin_config.data_in_num = self->sdin;
+
+    ret = i2s_set_pin(self->id, &pin_config);
+    switch (ret) {
+        case ESP_OK:
+            break;
+        case ESP_ERR_INVALID_ARG:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("I2S set pin: Parameter error"));
+            break;
+        case ESP_FAIL:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("I2S set pin: IO error"));
+            break;
+        default:
+            // this error not documented in ESP-IDF
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("I2S set pin: Undocumented error")); 
+            break;
+    }
+
+    self->used = true;
+}
+
+/******************************************************************************/
+// MicroPython bindings for I2S
+STATIC void machine_hw_i2s_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    machine_hw_i2s_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_printf(print, "I2S(id=%u, bck=%d, ws=%d, sdout=%d, sdin=%d\n"
+            "standard=%u, mode=%u,\n"
+            "dataformat=%u, channelformat=%u,\n"
+            "samplerate=%d,\n"
+            "dmacount=%d, dmalen=%d,\n"
+            "apllrate=%d)",
+            self->id, self->bck, self->ws, self->sdout, self->sdin,
+            self->standard, self->mode,
+            self->dataformat, self->channelformat,
+            self->samplerate,
+            self->dmacount, self->dmalen,
+            self->apllrate
+            );
+}
+
+STATIC mp_obj_t machine_hw_i2s_make_new(const mp_obj_type_t *type, size_t n_pos_args, size_t n_kw_args, const mp_obj_t *args) {
+    mp_arg_check_num(n_pos_args, n_kw_args, 1, MP_OBJ_FUN_ARGS_MAX, true);
+
+    machine_hw_i2s_obj_t *self;
+
+    // note: it is safe to assume that the arg pointer below references a positional argument because the arg check above
+    //       guarantees that at least one positional argument has been provided
+    i2s_port_t i2s_id = mp_obj_get_int(args[0]);
+    if (i2s_id == I2S_NUM_0) {
+        self = &machine_hw_i2s_obj[0];
+    } else if (i2s_id == I2S_NUM_1) {
+        self = &machine_hw_i2s_obj[1];
+    } else {
+        mp_raise_ValueError(MP_ERROR_TEXT("I2S ID is not valid"));
+    }
+
+    self->base.type = &machine_hw_i2s_type;
+    self->id = i2s_id;
+
+    // is I2S peripheral already in use?
+    if (self->used) {
+        mp_raise_ValueError(MP_ERROR_TEXT("I2S port is already in use"));
+    }
+
+    mp_map_t kw_args;
+    mp_map_init_fixed_table(&kw_args, n_kw_args, args + n_pos_args);
+    // note:  "args + 1" below has the effect of skipping over the ID argument
+    machine_hw_i2s_init_helper(self, n_pos_args - 1, args + 1, &kw_args);
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
+STATIC mp_obj_t machine_hw_i2s_init(mp_uint_t n_pos_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    // note:  "pos_args + 1" below has the effect of skipping over "self"
+    machine_hw_i2s_init_helper(pos_args[0], n_pos_args - 1, pos_args + 1, kw_args);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(machine_hw_i2s_init_obj, 1, machine_hw_i2s_init);
+
+STATIC mp_obj_t machine_hw_i2s_readinto(mp_uint_t n_pos_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_buf, ARG_timeout };
+    STATIC const mp_arg_t allowed_args[] = {
+        { MP_QSTR_buf,                      MP_ARG_REQUIRED | MP_ARG_OBJ,  {.u_obj = mp_const_none} },
+        { MP_QSTR_timeout, MP_ARG_KW_ONLY                   | MP_ARG_INT,  {.u_int = -1} },
+    };
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_pos_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(args), allowed_args, args);
+
+    machine_hw_i2s_obj_t *self = pos_args[0];
+    
+    if (!self->used) {
+        mp_raise_ValueError(MP_ERROR_TEXT("I2S port is not initialized"));
+    }
+
+    if (self->mode != (I2S_MODE_MASTER | I2S_MODE_RX) && self->mode != (I2S_MODE_MASTER | I2S_MODE_RX | I2S_MODE_PDM)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("I2S not configured for read method"));
+    }
+
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(args[ARG_buf].u_obj, &bufinfo, MP_BUFFER_WRITE);
+
+    TickType_t timeout_in_ticks = portMAX_DELAY;
+    if (args[ARG_timeout].u_int != -1) {
+        timeout_in_ticks = pdMS_TO_TICKS(args[ARG_timeout].u_int);
+    }
+
+    uint32_t num_bytes_read = 0;
+    esp_err_t ret = i2s_read(self->id, bufinfo.buf, bufinfo.len, &num_bytes_read, timeout_in_ticks);
+    switch (ret) {
+        case ESP_OK:
+            break;
+        case ESP_ERR_INVALID_ARG:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("I2S read: Parameter error"));
+            break;
+        default:
+            // this error not documented in ESP-IDF
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("I2S read: Undocumented error")); 
+            break;
+    }
+
+    return mp_obj_new_int(num_bytes_read);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(machine_hw_i2s_readinto_obj, 2, machine_hw_i2s_readinto);
+
+STATIC mp_obj_t machine_hw_i2s_write(mp_uint_t n_pos_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_buf, ARG_timeout };
+    STATIC const mp_arg_t allowed_args[] = {
+        { MP_QSTR_buf, MP_ARG_REQUIRED | MP_ARG_OBJ,  {.u_obj = mp_const_none} },
+        { MP_QSTR_timeout, MP_ARG_KW_ONLY | MP_ARG_INT,  {.u_int = -1} },
+    };
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_pos_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(args), allowed_args, args);
+
+    machine_hw_i2s_obj_t *self = pos_args[0];
+
+    if (!self->used) {
+        mp_raise_ValueError(MP_ERROR_TEXT("I2S port is not initialized"));
+    }
+
+    if (self->mode != (I2S_MODE_MASTER | I2S_MODE_TX)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("I2S not configured for write method"));
+    }
+    
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(args[ARG_buf].u_obj, &bufinfo, MP_BUFFER_WRITE);
+
+    TickType_t timeout_in_ticks = portMAX_DELAY;
+    if (args[ARG_timeout].u_int != -1) {
+        timeout_in_ticks = pdMS_TO_TICKS(args[ARG_timeout].u_int);
+    }
+
+    uint32_t num_bytes_written = 0;
+    esp_err_t ret = i2s_write(self->id, bufinfo.buf, bufinfo.len, &num_bytes_written, timeout_in_ticks);
+    switch (ret) {
+        case ESP_OK:
+            break;
+        case ESP_ERR_INVALID_ARG:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("I2S write: Parameter error"));
+            break;
+        default:
+            // this error not documented in ESP-IDF
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("I2S write: Undocumented error")); 
+            break;
+    }
+    
+    return mp_obj_new_int(num_bytes_written);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(machine_hw_i2s_write_obj, 2, machine_hw_i2s_write);
+
+STATIC mp_obj_t machine_hw_i2s_deinit(mp_obj_t self_in) {
+    machine_hw_i2s_obj_t *self = self_in;
+    i2s_driver_uninstall(self->id);
+    self->used = false;
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_hw_i2s_deinit_obj, machine_hw_i2s_deinit);
+
+STATIC const mp_rom_map_elem_t machine_hw_i2s_locals_dict_table[] = {
+    // Methods
+    { MP_ROM_QSTR(MP_QSTR_init),            MP_ROM_PTR(&machine_hw_i2s_init_obj) },
+    { MP_ROM_QSTR(MP_QSTR_readinto),        MP_ROM_PTR(&machine_hw_i2s_readinto_obj) },
+    { MP_ROM_QSTR(MP_QSTR_write),           MP_ROM_PTR(&machine_hw_i2s_write_obj) },
+    { MP_ROM_QSTR(MP_QSTR_deinit),          MP_ROM_PTR(&machine_hw_i2s_deinit_obj) },
+
+    // Constants
+    { MP_ROM_QSTR(MP_QSTR_NUM0),            MP_ROM_INT(I2S_NUM_0) },
+    { MP_ROM_QSTR(MP_QSTR_NUM1),            MP_ROM_INT(I2S_NUM_1) },
+    { MP_ROM_QSTR(MP_QSTR_PHILIPS),         MP_ROM_INT(I2S_COMM_FORMAT_I2S) },
+    { MP_ROM_QSTR(MP_QSTR_LSB),             MP_ROM_INT(I2S_COMM_FORMAT_I2S | I2S_COMM_FORMAT_I2S_LSB) },
+    { MP_ROM_QSTR(MP_QSTR_NO_PIN),          MP_ROM_INT(I2S_PIN_NO_CHANGE) },
+    // note:  ESP-IDF does not implement the MSB standard (even though the Macro I2S_COMM_FORMAT_I2S_MSB is defined)
+    { MP_ROM_QSTR(MP_QSTR_MASTER_RX),       MP_ROM_INT(I2S_MODE_MASTER | I2S_MODE_RX) },
+    { MP_ROM_QSTR(MP_QSTR_MASTER_TX),       MP_ROM_INT(I2S_MODE_MASTER | I2S_MODE_TX) },
+    { MP_ROM_QSTR(MP_QSTR_MASTER_PDW),      MP_ROM_INT(I2S_MODE_MASTER | I2S_MODE_RX | I2S_MODE_PDM) },
+    { MP_ROM_QSTR(MP_QSTR_B16),             MP_ROM_INT(I2S_BITS_PER_SAMPLE_16BIT) },
+    { MP_ROM_QSTR(MP_QSTR_B24),             MP_ROM_INT(I2S_BITS_PER_SAMPLE_24BIT) },
+    { MP_ROM_QSTR(MP_QSTR_B32),             MP_ROM_INT(I2S_BITS_PER_SAMPLE_32BIT) },
+    { MP_ROM_QSTR(MP_QSTR_RIGHT_LEFT),      MP_ROM_INT(I2S_CHANNEL_FMT_RIGHT_LEFT) },
+    { MP_ROM_QSTR(MP_QSTR_ALL_RIGHT),       MP_ROM_INT(I2S_CHANNEL_FMT_ALL_RIGHT) },
+    { MP_ROM_QSTR(MP_QSTR_ALL_LEFT),        MP_ROM_INT(I2S_CHANNEL_FMT_ALL_LEFT) },
+    { MP_ROM_QSTR(MP_QSTR_ONLY_RIGHT),      MP_ROM_INT(I2S_CHANNEL_FMT_ONLY_RIGHT) },
+    { MP_ROM_QSTR(MP_QSTR_ONLY_LEFT),       MP_ROM_INT(I2S_CHANNEL_FMT_ONLY_LEFT) },
+};
+MP_DEFINE_CONST_DICT(machine_hw_i2s_locals_dict, machine_hw_i2s_locals_dict_table);
+
+//const mp_obj_type_t machine_hw_i2s_type = {
+//    { &mp_type_type },
+//    .name = MP_QSTR_I2S,
+//    .print = machine_hw_i2s_print,
+//    .make_new = machine_hw_i2s_make_new,
+//    .locals_dict = (mp_obj_dict_t *) &machine_hw_i2s_locals_dict,
+//};
+
+MP_DEFINE_CONST_OBJ_TYPE(
+    machine_hw_i2s_type,
+    MP_QSTR_I2S,
+    MP_TYPE_FLAG_NONE,
+    make_new, machine_hw_i2s_make_new,
+    print, machine_hw_i2s_print,
+    locals_dict, (mp_obj_dict_t *) &machine_hw_i2s_locals_dict
+    );

--- a/ports/esp32/machine_pin.c
+++ b/ports/esp32/machine_pin.c
@@ -42,6 +42,7 @@
 #include "machine_pin.h"
 #include "machine_rtc.h"
 #include "modesp32.h"
+#include "esp_sleep.h"
 #include "genhdr/pins.h"
 
 #if CONFIG_IDF_TARGET_ESP32C3
@@ -92,6 +93,14 @@ void machine_pins_deinit(void) {
 STATIC void machine_pin_isr_handler(void *arg) {
     machine_pin_obj_t *self = arg;
     mp_obj_t handler = MP_STATE_PORT(machine_pin_irq_handler)[PIN_OBJ_PTR_INDEX(self)];
+    mp_sched_schedule(handler, MP_OBJ_FROM_PTR(self));
+    mp_hal_wake_main_task_from_isr();
+}
+
+STATIC void machine_pin_isr_handler_disable(void *arg) {
+    machine_pin_obj_t *self = arg;
+    gpio_intr_disable(PIN_OBJ_PTR_INDEX(self) );
+    mp_obj_t handler = MP_STATE_PORT(machine_pin_irq_handler)[PIN_OBJ_PTR_INDEX(self)];;
     mp_sched_schedule(handler, MP_OBJ_FROM_PTR(self));
     mp_hal_wake_main_task_from_isr();
 }
@@ -283,6 +292,22 @@ STATIC mp_obj_t machine_pin_on(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_on_obj, machine_pin_on);
 
+// pin.enable()
+STATIC mp_obj_t machine_pin_enable(mp_obj_t self_in) {
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    gpio_intr_enable(PIN_OBJ_PTR_INDEX(self));
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_enable_obj, machine_pin_enable);
+
+// pin.disable()
+STATIC mp_obj_t machine_pin_disable(mp_obj_t self_in) {
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    gpio_intr_disable(PIN_OBJ_PTR_INDEX(self));
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_disable_obj, machine_pin_disable);
+
 // pin.irq(handler=None, trigger=IRQ_FALLING|IRQ_RISING)
 STATIC mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_handler, ARG_trigger, ARG_wake };
@@ -305,8 +330,8 @@ STATIC mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_
         if ((trigger == GPIO_INTR_LOW_LEVEL || trigger == GPIO_INTR_HIGH_LEVEL) && wake_obj != mp_const_none) {
             mp_int_t wake;
             if (mp_obj_get_int_maybe(wake_obj, &wake)) {
-                if (wake < 2 || wake > 7) {
-                    mp_raise_ValueError(MP_ERROR_TEXT("bad wake value"));
+                if (wake != MACHINE_WAKE_SLEEP) {
+                    mp_raise_ValueError(MP_ERROR_TEXT("deep sleep not supported for gpio wake"));
                 }
             } else {
                 mp_raise_ValueError(MP_ERROR_TEXT("bad wake value"));
@@ -316,32 +341,30 @@ STATIC mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_
                 mp_raise_ValueError(MP_ERROR_TEXT("no resources"));
             }
 
-            if (!RTC_IS_VALID_EXT_PIN(index)) {
-                mp_raise_ValueError(MP_ERROR_TEXT("invalid pin for wake"));
+            gpio_wakeup_enable(index, trigger);
+            if (esp_sleep_enable_gpio_wakeup() != ESP_OK) {
+                mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("esp_sleep_enable_gpio_wakeup() failed"));
             }
 
-            if (machine_rtc_config.ext0_pin == -1) {
-                machine_rtc_config.ext0_pin = index;
-            } else if (machine_rtc_config.ext0_pin != index) {
-                mp_raise_ValueError(MP_ERROR_TEXT("no resources"));
-            }
-
-            machine_rtc_config.ext0_level = trigger == GPIO_INTR_LOW_LEVEL ? 0 : 1;
-            machine_rtc_config.ext0_wake_types = wake;
         } else {
-            if (machine_rtc_config.ext0_pin == index) {
-                machine_rtc_config.ext0_pin = -1;
-            }
+            gpio_wakeup_disable(index);
+        }
 
-            if (handler == mp_const_none) {
-                handler = MP_OBJ_NULL;
-                trigger = 0;
-            }
-            gpio_isr_handler_remove(index);
-            MP_STATE_PORT(machine_pin_irq_handler)[index] = handler;
-            gpio_set_intr_type(index, trigger);
+        if (handler == mp_const_none) {
+            handler = MP_OBJ_NULL;
+            trigger = 0;
+        }
+        
+        gpio_isr_handler_remove(index);
+        MP_STATE_PORT(machine_pin_irq_handler)[index] = handler;
+        gpio_set_intr_type(index, trigger);
+
+        if (trigger == GPIO_INTR_LOW_LEVEL || trigger == GPIO_INTR_HIGH_LEVEL) {
+            gpio_isr_handler_add(index, machine_pin_isr_handler_disable, (void *)self);
+        } else {
             gpio_isr_handler_add(index, machine_pin_isr_handler, (void *)self);
         }
+
     }
 
     // return the irq object
@@ -362,6 +385,8 @@ STATIC const mp_rom_map_elem_t machine_pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_value), MP_ROM_PTR(&machine_pin_value_obj) },
     { MP_ROM_QSTR(MP_QSTR_off), MP_ROM_PTR(&machine_pin_off_obj) },
     { MP_ROM_QSTR(MP_QSTR_on), MP_ROM_PTR(&machine_pin_on_obj) },
+       { MP_ROM_QSTR(MP_QSTR_disable), MP_ROM_PTR(&machine_pin_disable_obj) },
+    { MP_ROM_QSTR(MP_QSTR_enable), MP_ROM_PTR(&machine_pin_enable_obj) },
     { MP_ROM_QSTR(MP_QSTR_irq), MP_ROM_PTR(&machine_pin_irq_obj) },
 
     // class attributes
@@ -375,8 +400,8 @@ STATIC const mp_rom_map_elem_t machine_pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_PULL_DOWN), MP_ROM_INT(GPIO_PULL_DOWN) },
     { MP_ROM_QSTR(MP_QSTR_IRQ_RISING), MP_ROM_INT(GPIO_INTR_POSEDGE) },
     { MP_ROM_QSTR(MP_QSTR_IRQ_FALLING), MP_ROM_INT(GPIO_INTR_NEGEDGE) },
-    { MP_ROM_QSTR(MP_QSTR_WAKE_LOW), MP_ROM_INT(GPIO_INTR_LOW_LEVEL) },
-    { MP_ROM_QSTR(MP_QSTR_WAKE_HIGH), MP_ROM_INT(GPIO_INTR_HIGH_LEVEL) },
+    { MP_ROM_QSTR(MP_QSTR_IRQ_LOW_LEVEL), MP_ROM_INT(GPIO_INTR_LOW_LEVEL) },
+    { MP_ROM_QSTR(MP_QSTR_IRQ_HIGH_LEVEL), MP_ROM_INT(GPIO_INTR_HIGH_LEVEL) },
     { MP_ROM_QSTR(MP_QSTR_DRIVE_0), MP_ROM_INT(GPIO_DRIVE_CAP_0) },
     { MP_ROM_QSTR(MP_QSTR_DRIVE_1), MP_ROM_INT(GPIO_DRIVE_CAP_1) },
     { MP_ROM_QSTR(MP_QSTR_DRIVE_2), MP_ROM_INT(GPIO_DRIVE_CAP_2) },

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -134,7 +134,7 @@ STATIC void mp_machine_set_freq(size_t n_args, const mp_obj_t *args) {
 
 STATIC void machine_sleep_helper(wake_type_t wake_type, size_t n_args, const mp_obj_t *args) {
     // First, disable any previously set wake-up source
-    esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_ALL);
+    // esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_ALL); // a bit drastic
 
     // Set the expiry time of the sleep, if given.
     if (n_args != 0) {

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -39,6 +39,17 @@
 #include "modmachine.h"
 #include "machine_rtc.h"
 
+
+typedef enum {
+    MP_PWRON_RESET = 1,
+    MP_HARD_RESET,
+    MP_WDT_RESET,
+    MP_DEEPSLEEP_RESET,
+    MP_SOFT_RESET
+} reset_reason_t;
+
+STATIC bool is_soft_reset = 0;
+
 #if MICROPY_HW_ENABLE_SDCARD
 #define MICROPY_PY_MACHINE_SDCARD_ENTRY { MP_ROM_QSTR(MP_QSTR_SDCard), MP_ROM_PTR(&machine_sdcard_type) },
 #else
@@ -63,6 +74,7 @@
     /* wake abilities */ \
     { MP_ROM_QSTR(MP_QSTR_SLEEP), MP_ROM_INT(MACHINE_WAKE_SLEEP) }, \
     { MP_ROM_QSTR(MP_QSTR_DEEPSLEEP), MP_ROM_INT(MACHINE_WAKE_DEEPSLEEP) }, \
+    { MP_ROM_QSTR(MP_QSTR_I2S), MP_ROM_PTR(&machine_hw_i2s_type) }, \
     \
     /* Reset reasons */ \
     { MP_ROM_QSTR(MP_QSTR_HARD_RESET), MP_ROM_INT(MP_HARD_RESET) }, \
@@ -79,16 +91,6 @@
     { MP_ROM_QSTR(MP_QSTR_TIMER_WAKE), MP_ROM_INT(ESP_SLEEP_WAKEUP_TIMER) }, \
     { MP_ROM_QSTR(MP_QSTR_TOUCHPAD_WAKE), MP_ROM_INT(ESP_SLEEP_WAKEUP_TOUCHPAD) }, \
     { MP_ROM_QSTR(MP_QSTR_ULP_WAKE), MP_ROM_INT(ESP_SLEEP_WAKEUP_ULP) }, \
-
-typedef enum {
-    MP_PWRON_RESET = 1,
-    MP_HARD_RESET,
-    MP_WDT_RESET,
-    MP_DEEPSLEEP_RESET,
-    MP_SOFT_RESET
-} reset_reason_t;
-
-STATIC bool is_soft_reset = 0;
 
 #if CONFIG_IDF_TARGET_ESP32C3
 int esp_clk_cpu_freq(void);

--- a/ports/esp32/modmachine.h
+++ b/ports/esp32/modmachine.h
@@ -12,6 +12,17 @@ typedef enum {
 extern const mp_obj_type_t machine_touchpad_type;
 extern const mp_obj_type_t machine_dac_type;
 extern const mp_obj_type_t machine_sdcard_type;
+extern const mp_obj_type_t machine_hw_i2s_type;
+extern const mp_obj_type_t machine_timer_type;
+extern const mp_obj_type_t machine_wdt_type;
+extern const mp_obj_type_t machine_pin_type;
+extern const mp_obj_type_t machine_adc_type;
+extern const mp_obj_type_t machine_pwm_type;
+extern const mp_obj_type_t machine_hw_i2c_type;
+extern const mp_obj_type_t machine_hw_spi_type;
+extern const mp_obj_type_t machine_uart_type;
+extern const mp_obj_type_t machine_rtc_type;
+
 
 void machine_init(void);
 void machine_deinit(void);
@@ -21,5 +32,7 @@ void machine_pwm_deinit_all(void);
 // TODO: void machine_rmt_deinit_all(void);
 void machine_timer_deinit_all(void);
 void machine_i2s_init0();
+
+
 
 #endif // MICROPY_INCLUDED_ESP32_MODMACHINE_H


### PR DESCRIPTION
**All the text below is now irrelevant because of @lana-chan 's [PR](https://github.com/micropython/micropython/pull/14176). I'm now trying to merge it with @jeffmer 's GPIO commit. To keep track of the changes go to [my fork](https://github.com/thiswillbeyourgithub/micropython/tree/remove_commit_since_berkeley_db)**

~~Hi,~~

~~So I made this draft PR to keep track and report on what I tried to get a recent micropython driver for the twatch V3 that supports PDM.~~

The idea came from [this message from @devnoname120](https://github.com/jeffmer/TTGO-T-watch-2020-Micropython-OS/issues/17#issuecomment-1725877391) where he mentions [this repo by @lemariva](https://github.com/lemariva/micropython-i2s-driver) which states:

> This repository adds I2S support to MicroPython for the ESP32 family. The code was taken from the PR, and was updated and modified to include the I2S-PDM mode. This mode is required by some MEMS microphones e.g. SPM1423.

I first tried to build and flash the most recent micropython [using @jeffmer 's commit for GPIO_WAKEUP](https://github.com/jeffmer/micropython/).

# Building the recent micropython

Steps I took to build and flash the recent micropython with GPIO_WAKEUP:
*(The instructions to build then compile were from [this README](https://github.com/jeffmer/micropython/tree/master/ports/esp32))*
1. `git clone -b v5.0.2 --recursive https://github.com/espressif/esp-idf.git`
2. `cd esp-idf && git checkout v5.0.2 && git submodule update --init --recursive && ./install.sh && source export.sh`
**Note: I think all of this has to happen in the same terminal window because the esp-idf export.sh changes some PATH needed for the make command**
3. `cd .. && git clone https://github.com/jeffmer/micropython/`
4. `cd micropython && make -C mpy-cross && cd ports/esp32 && make submodules && make BOARD=ESP32_GENERIC BOARD_VARIANT=SPIRAM`
5. `python -m esptool --port /dev/ttyACM0 erase_flash`
6. To flash using the commands from esp-idf you can use the command given as a final output from the `make` command. (something like `/home/USER/.espressif/python_env/idf5.0_py3.10_env/bin/python ../../../esp-idf/components/esptool_py/esptool/esptool.py -p /dev/ttyACM0 -b 460800 --before default_reset --after hard_reset --chip esp32  write_flash --flash_mode dio --flash_size 4MB --flash_freq 40m 0x1000 build-ESP32_GENERIC-SPIRAM/bootloader/bootloader.bin 0x8000 build-ESP32_GENERIC-SPIRAM/partition_table/partition-table.bin 0x10000 build-ESP32_GENERIC-SPIRAM/micropython.bin`). I think you can alternatively use `python -m esptool --port /dev/ttyACM0 --chip esp32 write_flash -z 0x1000 build-ESP32_GENERIC-SPIRAM/firmware.bin`
7. `cd .. && git clone https://github.com/jeffmer/TTGO-T-watch-2020-Micropython-OS/ && cd TTGO-T-watch-2020-Micropython-OS/src`
8. modify the path to mpy-cross in `compile.sh` to point to the one built in the micropython folder
9. `./compile.sh`
10. `./install.sh`


This was succesful and produced a build that flashed without issues on my V3 watch.

**Now, to get the commit from @lemariva working without knowing any C I had to do some modifications to the commit code. As I don't know C I don't really know if some of my changes invalidated the commit or not but I got it flashing and booting as normal.**

# Trying to add PDM support

There are 4 files in @lemariva's commit:

## modmachine.h
* I added all the missing lines from the commit to the micropython branch. That amounted to:
  ```
  +extern const mp_obj_type_t machine_hw_i2s_type;
  +extern const mp_obj_type_t machine_timer_type;
  +extern const mp_obj_type_t machine_wdt_type;
  +extern const mp_obj_type_t machine_pin_type;
  +extern const mp_obj_type_t machine_adc_type;
  +extern const mp_obj_type_t machine_pwm_type;
  +extern const mp_obj_type_t machine_hw_i2c_type;
  +extern const mp_obj_type_t machine_hw_spi_type;
  +extern const mp_obj_type_t machine_uart_type;
  +extern const mp_obj_type_t machine_rtc_type;
  ```

## modmachine.c
* I needed to add `+    { MP_ROM_QSTR(MP_QSTR_I2S), MP_ROM_PTR(&machine_hw_i2s_type) }, \` in the section `wake abilities` but I ran into some issues so I ended up moving `typedef enum` and a declaration of `is_soft_reset` just a bit higher in the code.

## Makefile
* apparently I needed to add a line to make sure that make would compile `machine_i2s.c` but the Makefile changed at lot between the recent micropython and the one for @lemariva so I ended up ignoring this step as I think the Makefile was using a glob to compile all *.c files. Given that I add compiling issue in machine_i2s.c I think this was true.

## machine_i2s.c
* so apparently this file did not exist in micropython at the time of lemariva so at the time I just needed to add it directly. But now there is a machine_i2s.c file in micropython so I needed to somehow merge the changes.

* What I did was paste the whole machine_i2s.c file from lemariva at the end of the recent one, try to compile then make sense of the errors.
* I also added at the top some `#include` statements.

**The first change was fixed by @DonvdH in [this message](https://github.com/jeffmer/TTGO-T-watch-2020-Micropython-OS/issues/17#issuecomment-1962893844)**
~~* The first notable change was that in lemariva there is a line:~~
```
STATIC machine_hw_i2s_obj_t machine_hw_i2s_obj[I2S_NUM_MAX] = {
        [0].used = false,
        [1].used = false };
```
~~that returned error:~~
```
/home/USER/twatch_microphone/jeffmer_micropython/ports/esp32/machine_i2s.c:510:48: error: 'I2S_NUM_MAX' undeclared here (not
 in a function); did you mean 'I2S_NUM_1'?
```
~~So I changed `I2S_NUM_MAX` to `I2S_NUM_1` and got:~~
```~~
In file included from /home/USER/twatch_microphone/jeffmer_micropython/extmod/machine_i2s.c:128:
/home/USER/twatch_microphone/jeffmer_micropython/ports/esp32/machine_i2s.c:512:10: error: array index in initializer exceeds
 array bounds                                                                                                                        512 |         [1].used = false };                                                                                                      |          ^
```
~~So I tried `I2S_NUM_0` and got the same.
Finally tried with `I2S_NUM_AUTO` and got it passed that line.~~
~~**I have no idea what I'm doing.**~~

* The second most notable change was that at the end of the file, lemariva ended up with:
```
const mp_obj_type_t machine_hw_i2s_type = {
{ &mp_type_type },
.name = MP_QSTR_I2S,
.print = machine_hw_i2s_print,
.make_new = machine_hw_i2s_make_new,
.locals_dict = (mp_obj_dict_t *) &machine_hw_i2s_locals_dict,
};
```
which returned errors like `error: 'mp_obj_type_t' {aka 'const struct _mp_obj_type_t'} has no member named 'locals_dict'` also for `.make_new` and `.print`.
Noticing that the end of `machine_i2c.c` ended up with a similar looking bunch of lines I intuitively merged it to:
```
MP_DEFINE_CONST_OBJ_TYPE(
machine_hw_i2s_type,
MP_QSTR_I2S,
MP_TYPE_FLAG_NONE,
make_new, machine_hw_i2s_make_new,
print, machine_hw_i2s_print,
locals_dict, (mp_obj_dict_t *) &machine_hw_i2s_locals_dict
);
```
which produced a build that apparently worked and successfuly built.

I think it was successful in the sense that it resulted in a flashable build, but I got many warnings and no errors, but all from machine_i2s. Here are the warnigs I got:
```
twatch_microphone/jeffmer_micropython/py/mpstate.h:35,
             from /home/USER/twatch_microphone/jeffmer_micropython/py/runtime.h:29,
             from /home/USER/twatch_microphone/jeffmer_micropython/extmod/machine_i2s.c:28:
/home/USER/twatch_microphone/jeffmer_micropython/ports/esp32/machine_i2s.c:770:63: warning: initialization of 'void * (*)(size_t,  void * const*, mp_map_t *)' {aka 'void * (*)(unsigned int,  void * const*, struct _mp_map_t *)'} from incompatible pointer type 'void * (*)(mp_uint_t,  void * const*, mp_map_t *)' {aka 'void * (*)(long unsigned int,  void * const*, struct _mp_map_t *)'} [-Wincompatible-pointer-types]
  770 | STATIC MP_DEFINE_CONST_FUN_OBJ_KW(machine_hw_i2s_init_obj, 1, machine_hw_i2s_init);
      |                                                               ^~~~~~~~~~~~~~~~~~~
/home/USER/twatch_microphone/jeffmer_micropython/py/obj.h:391:104: note: in definition of macro 'MP_DEFINE_CONST_FUN_OBJ_KW'
  391 |     {{&mp_type_fun_builtin_var}, MP_OBJ_FUN_MAKE_SIG(n_args_min, MP_OBJ_FUN_ARGS_MAX, true), .fun.kw = fun_name}
      |                                                                                                        ^~~~~~~~
/home/USER/twatch_microphone/jeffmer_micropython/ports/esp32/machine_i2s.c:770:63: note: (near initialization for 'machine_hw_i2s_init_obj.fun.kw')
  770 | STATIC MP_DEFINE_CONST_FUN_OBJ_KW(machine_hw_i2s_init_obj, 1, machine_hw_i2s_init);
      |                                                               ^~~~~~~~~~~~~~~~~~~
/home/USER/twatch_microphone/jeffmer_micropython/py/obj.h:391:104: note: in definition of macro 'MP_DEFINE_CONST_FUN_OBJ_KW'
  391 |     {{&mp_type_fun_builtin_var}, MP_OBJ_FUN_MAKE_SIG(n_args_min, MP_OBJ_FUN_ARGS_MAX, true), .fun.kw = fun_name}
      |                                                                                                        ^~~~~~~~
In file included from /home/USER/twatch_microphone/jeffmer_micropython/extmod/machine_i2s.c:128:
/home/USER/twatch_microphone/jeffmer_micropython/ports/esp32/machine_i2s.c: In function 'machine_hw_i2s_readinto':
/home/USER/twatch_microphone/jeffmer_micropython/ports/esp32/machine_i2s.c:800:66: warning: passing argument 4 of 'i2s_read' from incompatible pointer type [-Wincompatible-pointer-types]
  800 |     esp_err_t ret = i2s_read(self->id, bufinfo.buf, bufinfo.len, &num_bytes_read, timeout_in_ticks);
      |                                                                  ^~~~~~~~~~~~~~~
      |                                                                  |
      |                                                                  uint32_t * {aka long unsigned int *}
In file included from /home/USER/twatch_microphone/jeffmer_micropython/ports/esp32/mpconfigport.h:12,
                 from /home/USER/twatch_microphone/jeffmer_micropython/py/mpconfig.h:91,
                 from /home/USER/twatch_microphone/jeffmer_micropython/py/mpstate.h:31,
                 from /home/USER/twatch_microphone/jeffmer_micropython/py/runtime.h:29,
                 from /home/USER/twatch_microphone/jeffmer_micropython/extmod/machine_i2s.c:28:
/home/USER/twatch_microphone/esp-idf/components/driver/deprecated/driver/i2s.h:208:73: note: expected 'size_t *' {aka 'unsigned int *'} but argument is of type 'uint32_t *' {aka 'long unsigned int *'}
  208 | esp_err_t i2s_read(i2s_port_t i2s_num, void *dest, size_t size, size_t *bytes_read, TickType_t ticks_to_wait);
      |                                                                 ~~~~~~~~^~~~~~~~~~
In file included from /home/USER/twatch_microphone/jeffmer_micropython/py/mpstate.h:35,
                 from /home/USER/twatch_microphone/jeffmer_micropython/py/runtime.h:29,
                 from /home/USER/twatch_microphone/jeffmer_micropython/extmod/machine_i2s.c:28:
/home/USER/twatch_microphone/jeffmer_micropython/ports/esp32/machine_i2s.c: At top level:
/home/USER/twatch_microphone/jeffmer_micropython/ports/esp32/machine_i2s.c:815:67: warning: initialization of 'void * (*)(size_t,  void * const*, mp_map_t *)' {aka 'void * (*)(unsigned int,  void * const*, struct _mp_map_t *)'} from incompatible pointer type 'void * (*)(mp_uint_t,  void * const*, mp_map_t *)' {aka 'void * (*)(long unsigned int,  void * const*, struct _mp_map_t *)'} [-Wincompatible-pointer-types]
  815 | STATIC MP_DEFINE_CONST_FUN_OBJ_KW(machine_hw_i2s_readinto_obj, 2, machine_hw_i2s_readinto);
      |                                                                   ^~~~~~~~~~~~~~~~~~~~~~~
/home/USER/twatch_microphone/jeffmer_micropython/py/obj.h:391:104: note: in definition of macro 'MP_DEFINE_CONST_FUN_OBJ_KW'
  391 |     {{&mp_type_fun_builtin_var}, MP_OBJ_FUN_MAKE_SIG(n_args_min, MP_OBJ_FUN_ARGS_MAX, true), .fun.kw = fun_name}
      |                                                                                                        ^~~~~~~~
/home/USER/twatch_microphone/jeffmer_micropython/ports/esp32/machine_i2s.c:815:67: note: (near initialization for 'machine_hw_i2s_readinto_obj.fun.kw')
  815 | STATIC MP_DEFINE_CONST_FUN_OBJ_KW(machine_hw_i2s_readinto_obj, 2, machine_hw_i2s_readinto);
      |                                                                   ^~~~~~~~~~~~~~~~~~~~~~~
/home/USER/twatch_microphone/jeffmer_micropython/py/obj.h:391:104: note: in definition of macro 'MP_DEFINE_CONST_FUN_OBJ_KW'
  391 |     {{&mp_type_fun_builtin_var}, MP_OBJ_FUN_MAKE_SIG(n_args_min, MP_OBJ_FUN_ARGS_MAX, true), .fun.kw = fun_name}
      |                                                                                                        ^~~~~~~~
In file included from /home/USER/twatch_microphone/jeffmer_micropython/extmod/machine_i2s.c:128:
/home/USER/twatch_microphone/jeffmer_micropython/ports/esp32/machine_i2s.c: In function 'machine_hw_i2s_write':
/home/USER/twatch_microphone/jeffmer_micropython/ports/esp32/machine_i2s.c:845:67: warning: passing argument 4 of 'i2s_write' from incompatible pointer type [-Wincompatible-pointer-types]
  845 |     esp_err_t ret = i2s_write(self->id, bufinfo.buf, bufinfo.len, &num_bytes_written, timeout_in_ticks);
      |                                                                   ^~~~~~~~~~~~~~~~~~
      |                                                                   |
      |                                                                   uint32_t * {aka long unsigned int *}
In file included from /home/USER/twatch_microphone/jeffmer_micropython/ports/esp32/mpconfigport.h:12,
                 from /home/USER/twatch_microphone/jeffmer_micropython/py/mpconfig.h:91,
                 from /home/USER/twatch_microphone/jeffmer_micropython/py/mpstate.h:31,
                 from /home/USER/twatch_microphone/jeffmer_micropython/py/runtime.h:29,
                 from /home/USER/twatch_microphone/jeffmer_micropython/extmod/machine_i2s.c:28:
/home/USER/twatch_microphone/esp-idf/components/driver/deprecated/driver/i2s.h:155:79: note: expected 'size_t *' {aka 'unsigned int *'} but argument is of type 'uint32_t *' {aka 'long unsigned int *'}
  155 | esp_err_t i2s_write(i2s_port_t i2s_num, const void *src, size_t size, size_t *bytes_written, TickType_t ticks_to_wait);
      |                                                                       ~~~~~~~~^~~~~~~~~~~~~
In file included from /home/USER/twatch_microphone/jeffmer_micropython/py/mpstate.h:35,
                 from /home/USER/twatch_microphone/jeffmer_micropython/py/runtime.h:29,
                 from /home/USER/twatch_microphone/jeffmer_micropython/extmod/machine_i2s.c:28:
/home/USER/twatch_microphone/jeffmer_micropython/ports/esp32/machine_i2s.c: At top level:
/home/USER/twatch_microphone/jeffmer_micropython/ports/esp32/machine_i2s.c:860:64: warning: initialization of 'void * (*)(size_t,  void * const*, mp_map_t *)' {aka 'void * (*)(unsigned int,  void * const*, struct _mp_map_t *)'} from incompatible pointer type 'void * (*)(mp_uint_t,  void * const*, mp_map_t *)' {aka 'void * (*)(long unsigned int,  void * const*, struct _mp_map_t *)'} [-Wincompatible-pointer-types]
  860 | STATIC MP_DEFINE_CONST_FUN_OBJ_KW(machine_hw_i2s_write_obj, 2, machine_hw_i2s_write);
      |                                                                ^~~~~~~~~~~~~~~~~~~~
/home/USER/twatch_microphone/jeffmer_micropython/py/obj.h:391:104: note: in definition of macro 'MP_DEFINE_CONST_FUN_OBJ_KW'
  391 |     {{&mp_type_fun_builtin_var}, MP_OBJ_FUN_MAKE_SIG(n_args_min, MP_OBJ_FUN_ARGS_MAX, true), .fun.kw = fun_name}
      |                                                                                                        ^~~~~~~~
/home/USER/twatch_microphone/jeffmer_micropython/ports/esp32/machine_i2s.c:860:64: note: (near initialization for 'machine_hw_i2s_write_obj.fun.kw')
  860 | STATIC MP_DEFINE_CONST_FUN_OBJ_KW(machine_hw_i2s_write_obj, 2, machine_hw_i2s_write);
      |                                                                ^~~~~~~~~~~~~~~~~~~~
/home/USER/twatch_microphone/jeffmer_micropython/py/obj.h:391:104: note: in definition of macro 'MP_DEFINE_CONST_FUN_OBJ_KW'
  391 |     {{&mp_type_fun_builtin_var}, MP_OBJ_FUN_MAKE_SIG(n_args_min, MP_OBJ_FUN_ARGS_MAX, true), .fun.kw = fun_name}
      |                                                                                                        ^~~~~~~~
```

At the end of all this I flashed the whole thing using the above commands and the watch booted successfuly. But now what? when doing `from machine import I2S ; dir(I2S)` I don't see a PDM mode, but I don't if that's expected or not. Basically I don't know if my commit was working or not, if it did change the build, if it added functionnality or not etc.


# Please help
* Can anyone tell me if the build appeared succesful?
* Were my modification to micropython sane or did I botch it? I have a feeling that my merging of the `machine_i2s.c` files was a problem.
* If my modifications worked, how should I test it? Reminder: my goal is to be able to record sounds on my watch.